### PR TITLE
Add ruby 3.2 and 3.3 to tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.3'
+          - '3.3'
+          - '3.2'
+          - '3.1'
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"
 
-gem "rubocop", "~> 1.21"
-
 group :test do
   gem 'vcr'
   gem 'webmock'

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,4 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
-require "rubocop/rake_task"
-
-RuboCop::RakeTask.new
-
-task default: %i[test rubocop]
+task default: %i[test]


### PR DESCRIPTION
Remove rubocop gem for now. Will add back in later. Maybe.